### PR TITLE
Update IfcWallTypeEnum.md

### DIFF
--- a/docs/schemas/shared/IfcSharedBldgElements/Types/IfcWallTypeEnum.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/Types/IfcWallTypeEnum.md
@@ -24,7 +24,7 @@ A movable wall that is either movable, such as folding wall or a sliding wall, o
 A wall-like barrier to protect human or vehicle from falling, or to prevent the spread of fires. Often designed at the edge of balconies, terraces or roofs, or along edges of bridges.
 
 ### PARTITIONING
-A wall designed to partition spaces that can be a light-weight, sandwich-like construction (e.g. using gypsum board) or massive walls made out of blocks or elements (e.g. using gipsym, light-weight concrete of calcium silicate). Partitioning walls are normally non load bearing.
+A wall designed to partition spaces that can be a light-weight, layered system (e.g. using gypsum board) or solid wall made out of blocks or elements (e.g. using gypsum, light-weight concrete or calcium silicate). Partitioning walls are non-load-bearing.
 
 ### PLUMBINGWALL
 A pier, or enclosure, or encasement, normally used to enclose plumbing in sanitary rooms. Such walls often do not extend to the ceiling.

--- a/docs/schemas/shared/IfcSharedBldgElements/Types/IfcWallTypeEnum.md
+++ b/docs/schemas/shared/IfcSharedBldgElements/Types/IfcWallTypeEnum.md
@@ -24,7 +24,7 @@ A movable wall that is either movable, such as folding wall or a sliding wall, o
 A wall-like barrier to protect human or vehicle from falling, or to prevent the spread of fires. Often designed at the edge of balconies, terraces or roofs, or along edges of bridges.
 
 ### PARTITIONING
-A wall designed to partition spaces that often has a light-weight, sandwich-like construction (e.g. using gypsum board). Partitioning walls are normally non load bearing.
+A wall designed to partition spaces that can be a light-weight, sandwich-like construction (e.g. using gypsum board) or massive walls made out of blocks or elements (e.g. using gipsym, light-weight concrete of calcium silicate). Partitioning walls are normally non load bearing.
 
 ### PLUMBINGWALL
 A pier, or enclosure, or encasement, normally used to enclose plumbing in sanitary rooms. Such walls often do not extend to the ceiling.


### PR DESCRIPTION
since STANDARD will be deprecated, there do not seems to be a place for gypsum-block walls and other light weight partitioning walls. PARTITIONING is now described as a light-weight, sandwich construction. I think the massive non-loadbearing walls should be included as well. This is not a change, just an addition to the description.