### PR TITLE
Restrict Fraction to Volume in IfcMaterialConstituent

### DIFF
--- a/docs/schemas/resource/IfcMaterialResource/Entities/IfcMaterialConstituent.md
+++ b/docs/schemas/resource/IfcMaterialResource/Entities/IfcMaterialConstituent.md
@@ -18,7 +18,7 @@ Definition of the material constituent in descriptive terms.
 Reference to the material from which the constituent is constructed.
 
 ### Fraction
-Optional provision of a fraction of the total amount (volume or weight) that applies to the _IfcMaterialConstituentSet_ that is contributed by this _IfcMaterialConstituent_.
+Optional provision of a fraction of the total volume that applies to the _IfcMaterialConstituentSet_ that is contributed by this _IfcMaterialConstituent_.
 
 ### Category
 Category of the material constituent, e.g. the role it has in the constituent set it belongs to.


### PR DESCRIPTION
### Description

This pull request refines the definition of the Fraction attribute in the IfcMaterialConstituent entity. Previously, Fraction could represent volume or weight, leading to potential inconsistencies.

### Change

Volume-Specific Fraction: The Fraction attribute now exclusively refers to the volume proportion of a material constituent within the overall material set. This aligns with the inherent nature of material constituents in construction, where volume is the primary concern.

### Rationale
There's limited practical use for specifying weight ratios between components like concrete, insulation, or reinforcement steel. Weight becomes relevant after the volume is established. By focusing on volume, we ensure consistent and meaningful data exchange within BIM workflows.

### Benefits
Enhances data clarity and consistency across BIM models.
Eliminates ambiguity during IFC data interpretation.