### PR TITLE
IfcTextLiteral does not have the same "Abstract" designation as others

### DIFF
--- a/docs/schemas/resource/IfcPresentationDefinitionResource/Entities/IfcTextLiteral.md
+++ b/docs/schemas/resource/IfcPresentationDefinitionResource/Entities/IfcTextLiteral.md
@@ -1,3 +1,5 @@
+![image](https://github.com/user-attachments/assets/d496b421-29d2-435b-8210-2d395f883c82)
+
 # IfcTextLiteral
 
 The text literal is a geometric representation item which describes a text string using a string literal and additional position and path information. The text size and appearance is determined by the _IfcTextStyle_ that is associated to the _IfcTextLiteral_ through an _IfcStyledItem_.


### PR DESCRIPTION
I just did a screen clip and pasted the graphic here. There is obviously a different mechanism to identify entities as abstract.