### PR TITLE
Add `IfcCompositeCurve` as possible reference for `IfcOffsetCurveByDistances` in `IfcAlignment` spec

### DIFF
--- a/docs/schemas/core/IfcProductExtension/Entities/IfcAlignment.md
+++ b/docs/schemas/core/IfcProductExtension/Entities/IfcAlignment.md
@@ -26,7 +26,7 @@ Supported shape representations of _IfcAlignment_ are:
 * _IfcCompositeCurve_ as a 2D horizontal alignment (represented by its horizontal alignment segments), without a vertical layout.
 * _IfcGradientCurve_ as a 3D horizontal and vertical alignment (represented by their alignment segments), without a cant layout.
 * _IfcSegmentedReferenceCurve_ as a 3D curve defined relative to an _IfcGradientCurve_ to incorporate the application of cant.
-* _IfcOffsetCurveByDistances_ as a 2D or 3D curve defined relative to an _IfcGradientCurve_ or another _IfcOffsetCurveByDistances_.
+* _IfcOffsetCurveByDistances_ as a 2D or 3D curve defined relative to an _IfcCompositeCurve_, _IfcGradientCurve_ or another _IfcOffsetCurveByDistances_.
 * _IfcPolyline_ or _IfcIndexedPolyCurve_ as a 3D alignment by a 3D polyline representation (such as coming from a survey).
 * _IfcPolyline_ or _IfcIndexedPolyCurve_ as a 2D horizontal alignment by a 2D polyline representation (such as in very early planning phases or as a map representation).
 


### PR DESCRIPTION
As defined, IfcOffsetCurveByDistances can never by a 2D curve. In the proposed (and subsequently withdrawn) [IFC 4.2 specification IfcOffsetCurveByDistances](https://standards.buildingsmart.org/IFC/DEV/IFC4_2/FINAL/HTML/) was defined as "IfcOffsetCurveByDistances as a 2D or 3D curve defined relative to an IfcAlignmentCurve or another IfcOffsetCurveByDistances".

IfcAlignmentCurve had the property of being either 2D or 3D. This property was lost when IfcAlignmentCurve was replaced with IfcGradientCurve in IFC 4.3.

This change has been discussed in the Implementors Forum
https://github.com/buildingSMART/IFC4.x-IF/issues/139
Also see
https://github.com/buildingSMART/IFC4.3.x-development/issues/733 for potential rules for IfcOffsetCurveByDistances
