### PR TITLE
Alignment Layout - Reusing Horizontal Layout

### DIFF
--- a/docs/templates/Object Composition/Nesting/Alignment Layouts/Alignment Layout - Reusing Horizontal Layout/README.md
+++ b/docs/templates/Object Composition/Nesting/Alignment Layouts/Alignment Layout - Reusing Horizontal Layout/README.md
@@ -5,6 +5,8 @@ Nesting and aggregation relationships between _IfcAlignment_'s and their layouts
 
 In the diagram below is an example of a *parent* alignment, with the horizontal layout, and two *child* alignments, one with a vertical layout, and the other with a vertical and a cant layout; both re-using the definition of the horizontal layout from the *parent* alignment.
 
+At most, one *child* alignment with vertical and cant layout is permissible. Viennese Bend cant segments influece the geometry of the horizontal Viennese Bend transition curve segment. In general, having more than one cant layout will result in non-unique horizontal geomtry.
+
 When defining the list of segments for the business logic (i.e., _IfcAlignmentHorizontalSegment_, _IfcAlignmentVerticalSegment_, _IfcAlignmentCantSegment_):
 
 1. A **zero-length segment** shall be added, at the end of the list of segments for _IfcAlignmentSegment.DesignParameters_.


### PR DESCRIPTION
The horizontal geometry of a Viennese Bend transition curve depends on the corresponding Viennese Bend cant segment. Specifically, the Quadratic, Cubic, Quartic, and Quintic terms of the seventh-order polynomial spiral function depend on `IfcAlignmentCantSegment.StartCantLeft/EndCantLeft/StartCantRight/EndCantRight` attributes.

In the special case of more than one child alignment with cant layouts, and those cant layouts have Viennese Bend cant segment with different parameters, the geometry of the horizontal Viennese Bend transition curve is not unique. The geometry of the transition curve segment will depend on which cant segment is used to compute the horizontal geometry.