### PR TITLE
(on IfcReferent) Add note on ordering of starting referent when nested in IfcAlignment

### DIFF
--- a/docs/schemas/core/IfcProductExtension/Entities/IfcReferent.md
+++ b/docs/schemas/core/IfcProductExtension/Entities/IfcReferent.md
@@ -11,7 +11,7 @@ Referents may be used for several scenarios:
 * indicating broken chainage where distance measurements reset or reverse directions, or have jumps.
 * indicating domain-specific design parameters (via property sets) at locations along an alignment curve
 
-> NOTE Referents can be nested to alignments, using _IfcRelNests_, to describe stations along an alignment. Being _IfcRelNests.RelatedObjects_ an ordered list, the first nested referent is the starting station of a given alignment. _IfcRelNests_ must preceed IfcAlignmentHorizontal, IfcAlignmentVertical, and IfcAlignmentCant when present in the same _IfcRelNests.RelatedObjects_ list.
+> NOTE Referents can be nested to alignments, using _IfcRelNests_, to describe stations along an alignment. Being _IfcRelNests.RelatedObjects_ an ordered list, the first nested referent is the starting station of a given alignment. _IfcReferent_ must preceed IfcAlignmentHorizontal, IfcAlignmentVertical, and IfcAlignmentCant when present in the same _IfcRelNests.RelatedObjects_ list.
 
 > NOTE The stationing value of any object can be provided, using an _IfcReferent_ and the respective _Pset_Stationing_. The relationship between the given object and the referent indicating its stationing value is an _IfcRelPositions_. 
 

--- a/docs/schemas/core/IfcProductExtension/Entities/IfcReferent.md
+++ b/docs/schemas/core/IfcProductExtension/Entities/IfcReferent.md
@@ -11,7 +11,7 @@ Referents may be used for several scenarios:
 * indicating broken chainage where distance measurements reset or reverse directions, or have jumps.
 * indicating domain-specific design parameters (via property sets) at locations along an alignment curve
 
-> NOTE Referents can be nested to alignments, using _IfcRelNests_, to describe stations along an alignment. Being _IfcRelNests.RelatedObjects_ an ordered list, the first nested referent is the starting station of a given alignment.
+> NOTE Referents can be nested to alignments, using _IfcRelNests_, to describe stations along an alignment. Being _IfcRelNests.RelatedObjects_ an ordered list, the first nested referent is the starting station of a given alignment. _IfcRelNests_ must preceed IfcAlignmentHorizontal, IfcAlignmentVertical, and IfcAlignmentCant when present in the same _IfcRelNests.RelatedObjects_ list.
 
 > NOTE The stationing value of any object can be provided, using an _IfcReferent_ and the respective _Pset_Stationing_. The relationship between the given object and the referent indicating its stationing value is an _IfcRelPositions_. 
 


### PR DESCRIPTION
IfcRelNests.RelatedObjects is an ordered list. This change provides clarity that IfcReferent is to precede IfcAlignmentHorizontal in the ordered list. Such clarity does not currently exist in the documentation.