### PR TITLE
IfcAlignment - Improve section reference clarity by including "Partial Template"

### DIFF
--- a/docs/schemas/core/IfcProductExtension/Entities/IfcAlignment.md
+++ b/docs/schemas/core/IfcProductExtension/Entities/IfcAlignment.md
@@ -56,7 +56,7 @@ The alignment concept is organised into two parts. These two parts work together
 
 **Geometry definition:** the IFC schema provides well established IFC geometric entities to represent the business concepts. 
 
-A mapping between the *business logic* and its *geometry definition* in IFC is described by the concept templates related to the alignment geometry.
+A mapping between the *business logic* and its *geometry definition* in IFC is described by the partial concept templates related to the alignment geometry.
 
 
 ## Attributes


### PR DESCRIPTION
The mapping between the *business logic* and it's *geometry definition* is described in the Partial Template subsections of 4.2.2.1.

Adding the word *partial* clarifies where the guidance is located within the specification.