### PR TITLE
Add UniqueTags section to IfcOpenCrossProfileDef.md

### DIFF
--- a/docs/schemas/resource/IfcProfileResource/Entities/IfcOpenCrossProfileDef.md
+++ b/docs/schemas/resource/IfcProfileResource/Entities/IfcOpenCrossProfileDef.md
@@ -36,3 +36,7 @@ The list of slopes and the list of widths shall be of the same size.
 ### CorrespondingTags
 
 The list of tags shall have one more member.
+
+### UniqueTags
+
+The tags shall be unique


### PR DESCRIPTION
Added section for UniqueTags to specify uniqueness requirement. The specification is not explicit with respect to uniqueness of tags. This leads to two incompatible interpretations.
1. IfcOffsetCurveByDistances.Tag must be globally unique in the model.
2. Tags on IfcSectionedSurface and IfcSectionedSolidHorizontal must be unique.

For Case 1, consider IfcOpenCrossProfileDef.Tags=("A","B","C") or IfcIndexedPolyCurve.Points.TagList=("A","B","C") and IfcOffsetCurveByDistances.Name="C1" . Tag="A" and IfcOffsetCurveByDistances.Name="C2" . Tag="A" (e.g. two distinct offset curves with different BasisCurve with the same tag attribute). Which curve corresponds to point "A" in the profile? To avoid this problem, IfcOffsetCurvesByDistances.Tag must be unique for the entire model.

For Case 2, IfcSectionedSurface and IfcSectionedSolidHorizontal with Directrix = IfcOffsetCurveByDistances.BasisCurve each offset curve must have a unique tag that corresponds to the unique tag in IfcOpenCrossProfileDef.Tag or IfcIndexedPolyCurve.Points.TagList, otherwise there is no way to know which offset curve corresponds to which point in the cross section.

I don't believe Case 1 to be the intent of the specification. 

Implementers are better served if these specifications explicitly state the requirements for tag uniqueness.