### PR TITLE
Add IfcDerivedProfileDef to the AbV

### DIFF
--- a/docs/schemas/resource/IfcProfileResource/Entities/IfcDerivedProfileDef.md
+++ b/docs/schemas/resource/IfcProfileResource/Entities/IfcDerivedProfileDef.md
@@ -1,3 +1,5 @@
+AbV
+
 # IfcDerivedProfileDef
 
 _IfcDerivedProfileDef_ defines the profile by transformation from the parent profile. The transformation is given by a two dimensional transformation operator. Transformation includes translation, rotation, mirror and scaling. The latter can be uniform or non uniform. The derived profiles may be used to define swept surfaces, swept area solids or sectioned spines.


### PR DESCRIPTION
IfcSectionedSolidHorizontal https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcSectionedSolidHorizontal.htm indicates that IfcDerivedProfileDef can be used for the case of rotating a profile through a superelevation. For this reason, IfcDerivedProfileDef should be part of the AbV