### PR TITLE
[TF01] Material and profile properties

### DIFF
--- a/docs/schemas/resource/IfcPropertyResource/Entities/IfcProperty.md
+++ b/docs/schemas/resource/IfcPropertyResource/Entities/IfcProperty.md
@@ -34,3 +34,6 @@ User-defined constraints for the property.
 
 ### HasApprovals
 User-defined approvals for the property.
+
+### PartOfMaterialOrProfileProperties
+Reference to the IfcMaterialProperties by which the IfcProperty is referenced.

--- a/docs/schemas/resource/IfcPropertyResource/Entities/IfcProperty.md
+++ b/docs/schemas/resource/IfcPropertyResource/Entities/IfcProperty.md
@@ -36,4 +36,4 @@ User-defined constraints for the property.
 User-defined approvals for the property.
 
 ### PartOfMaterialOrProfileProperties
-Reference to the IfcMaterialProperties by which the IfcProperty is referenced.
+Reference to the IfcMaterialProperties or IfcProfileProperties by which the IfcProperty is referenced.

--- a/schemas/IfcPropertyResource.uml
+++ b/schemas/IfcPropertyResource.uml
@@ -320,7 +320,7 @@ OR (SIZEOF(DefiningValues) = SIZEOF(DefinedValues))</body>
       </ownedAttribute>
     </packagedElement>
     <packagedElement xmi:type="uml:Association" xmi:id="as_IfcExtendedProperties_Properties" name="Properties" memberEnd="at_IfcExtendedProperties_Properties as_IfcExtendedProperties_Properties_target_end">
-      <ownedEnd xmi:type="uml:Property" xmi:id="as_IfcExtendedProperties_Properties_target_end" name="" type="cl_IfcExtendedProperties" association="as_IfcExtendedProperties_Properties">
+      <ownedEnd xmi:type="uml:Property" xmi:id="as_IfcExtendedProperties_Properties_target_end" name="INV_PartOfMaterialOrProfileProperties_S[0:?]" type="cl_IfcExtendedProperties" association="as_IfcExtendedProperties_Properties">
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="as_IfcExtendedProperties_Properties_target_end_lower"/>
         <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="as_IfcExtendedProperties_Properties_target_end_upper" value="1"/>
       </ownedEnd>


### PR DESCRIPTION
Description: "Introduced an inverse attribute PartOfMaterialOrProfileProperties from property to the extended properties."
Scope: "ENTITY IfcProperty"

<img width="1032" height="520" alt="tf01_after" src="https://github.com/user-attachments/assets/fb0303e6-7314-486f-99d4-d3be9cb886d2" />