### PR TITLE
[TF05] Typo (on IFCSWEPTDISKSOLID's WR)

### DIFF
--- a/schemas/IfcGeometricModelResource.uml
+++ b/schemas/IfcGeometricModelResource.uml
@@ -344,7 +344,7 @@ END_FUNCTION;
         <specification xmi:type="uml:OpaqueExpression" xmi:id="cl_IfcBooleanClippingResult_FirstOperandType" name="FirstOperandType">
           <language>EXPRESS_WHERE</language>
           <body>('IFC4X3_ADD2.IFCSWEPTAREASOLID' IN TYPEOF(FirstOperand)) OR 
-('IFC4X3_ADD2.IFCSWEPTDISCSOLID' IN TYPEOF(FirstOperand)) OR 
+('IFC4X3_ADD2.IFCSWEPTDISKSOLID' IN TYPEOF(FirstOperand)) OR 
 ('IFC4X3_ADD2.IFCBOOLEANCLIPPINGRESULT' IN TYPEOF(FirstOperand))</body>
         </specification>
       </ownedRule>


### PR DESCRIPTION
Description: "Fixed typo "DISC" vs "DISK" in formal rule that now allows IfcSweptDiskSolid as a valid type."
Scope: "ENTITY IfcBooleanClippingResult, WHERE FirstOperandType"