### PR TITLE
[TM27] Voxels

### DIFF
--- a/docs/schemas/core/IfcProductExtension/Entities/IfcComplementaryData.md
+++ b/docs/schemas/core/IfcProductExtension/Entities/IfcComplementaryData.md
@@ -1,0 +1,6 @@
+# IfcComplementaryData
+
+A kind of product with the purpose of providing additional raw data, such as observations,  to other products. Complementary data may carry its own representation and shall be related to the main product using _IfcRelAssignsToProduct_.
+## Attributes
+
+## Formal Propositions

--- a/docs/schemas/core/IfcProductExtension/Entities/IfcIntegerVoxelData.md
+++ b/docs/schemas/core/IfcProductExtension/Entities/IfcIntegerVoxelData.md
@@ -1,0 +1,15 @@
+# IfcIntegerVoxelData
+
+The voxels represented by integer values.
+## Attributes
+
+### ValueData
+The values assigned to the voxels as raw integer typed data.
+
+### Unit
+An optional unit for the integer values.
+
+### Values
+Array of integer values on voxels accessible by the same index as that of the corresponding voxel geometric representation.
+
+## Formal Propositions

--- a/docs/schemas/core/IfcProductExtension/Entities/IfcLabelVoxelData.md
+++ b/docs/schemas/core/IfcProductExtension/Entities/IfcLabelVoxelData.md
@@ -1,0 +1,12 @@
+# IfcLabelVoxelData
+
+The voxels represented by label values.
+## Attributes
+
+### ValueData
+The values assigned to the voxels as raw label typed data.
+
+### Values
+Array of label values on voxels accessible by the same index as that of the corresponding voxel.
+
+## Formal Propositions

--- a/docs/schemas/core/IfcProductExtension/Entities/IfcLogicalVoxelData.md
+++ b/docs/schemas/core/IfcProductExtension/Entities/IfcLogicalVoxelData.md
@@ -1,0 +1,12 @@
+# IfcLogicalVoxelData
+
+The voxels represented by logical values.
+## Attributes
+
+### ValueData
+The values assigned to the voxels as raw logical typed data.
+
+### Values
+Array of logical values on voxels accessible by the same index as that of the corresponding voxel geometric representation.
+
+## Formal Propositions

--- a/docs/schemas/core/IfcProductExtension/Entities/IfcRealVoxelData.md
+++ b/docs/schemas/core/IfcProductExtension/Entities/IfcRealVoxelData.md
@@ -1,0 +1,15 @@
+# IfcRealVoxelData
+
+The voxels represented by real values.
+## Attributes
+
+### ValueData
+The values assigned to the voxels as raw real typed data.
+
+### Unit
+An optional unit for the real values.
+
+### Values
+Array of real values on voxels accessible by the same index as that of the corresponding voxel geometric representation.
+
+## Formal Propositions

--- a/docs/schemas/core/IfcProductExtension/Entities/IfcVectorVoxelData.md
+++ b/docs/schemas/core/IfcProductExtension/Entities/IfcVectorVoxelData.md
@@ -1,0 +1,15 @@
+# IfcVectorVoxelData
+
+The voxels represented by vector values.
+## Attributes
+
+### ValueData
+The values assigned to the voxels. First x, then y and lastly z.
+
+### Unit
+An optional unit for the vector values that overrides the default Magnitude IfcLengthMeasure.
+
+### Values
+Array of vector values on voxels accessible by the same index as that of the corresponding voxel geometric representation.
+
+## Formal Propositions

--- a/docs/schemas/core/IfcProductExtension/Entities/IfcVoxelData.md
+++ b/docs/schemas/core/IfcProductExtension/Entities/IfcVoxelData.md
@@ -1,0 +1,22 @@
+# IfcVoxelData
+
+Abstract class representing voxel data values that is assigned to _IfcProduct_ using the relationship _IfcRelAssignsToProduct_ and to a product representation, as _IfcVoxelGrid_, using _Representation_.
+The number of values shall correspond to the number of voxels in the voxel grid.
+## Attributes
+
+### ValueType
+An optional value type used for the values defined in one of the subtypes. Only the names (as labels) of the types available in the _IfcValue_ select type are allowed.
+
+### GridSize
+Derived attribute that represents the total number of voxels in the _IfcVoxelGrid_ that is used as the representation for the _IfcVoxelData_ instance.
+
+## Formal Propositions
+
+### IsAssignedToProduct
+_IfcVoxelData_ shall have exactly one assignment relationship of type _IfcRelAssignsToProduct_ to a product.
+
+### VoxelGridRepresentation
+_IfcVoxelData_ shall have a product definition shape and there shall be exactly one _IfcShapeRepresentation_ in _IfcProductDefinitionShape_._Representations_ that has exactly one geometric item _IfcVoxelGrid_.
+
+### SameRepresentation
+The assigned _IfcProduct_ shall have the same shape representation.

--- a/docs/schemas/resource/IfcGeometricModelResource/Entities/IfcVoxelGrid.md
+++ b/docs/schemas/resource/IfcGeometricModelResource/Entities/IfcVoxelGrid.md
@@ -1,0 +1,28 @@
+# IfcVoxelGrid
+
+An _IfcVoxelGrid_ representation is a 3D solid shape representation that is compiled of a series of regular blocks placed inside a predefined grid.
+## Attributes
+
+### VoxelSizeX
+Size of voxels in the X axis.
+
+### VoxelSizeY
+Size of voxels in the Y axis.
+
+### VoxelSizeZ
+Size of voxels in the Z axis.
+
+### NumberOfVoxelsX
+Number of voxels along the X axis.
+
+### NumberOfVoxelsY
+Number of voxels along the Y axis.
+
+### NumberOfVoxelsZ
+NumberOf voxels along the Z axis.
+
+### Voxels
+Indication of voxels on the grid. The array is one-dimensional where values are distributed in the following order:
+along X, then Y and finally Z.
+
+## Formal Propositions

--- a/docs/schemas/resource/IfcGeometryResource/Functions/IfcListToExpandedArray.md
+++ b/docs/schemas/resource/IfcGeometryResource/Functions/IfcListToExpandedArray.md
@@ -1,0 +1,5 @@
+# IfcListToExpandedArray
+
+This function converts a generic list to an array with newly determined array bounds. If the array bounds are incompatible with the number of elements in the conditional list (number of elements in the list has to be smaller than the array upper bound and the number of values has to match the number of true values from Condition) a null result is returned. This function is used to construct the array of voxel values in IfcVoxelData based on the its IfcVoxelGrid geometric representation.
+
+> HISTORY  New function in IFC4X4

--- a/schemas/IfcGeometricModelResource.uml
+++ b/schemas/IfcGeometricModelResource.uml
@@ -1203,5 +1203,43 @@ END_FUNCTION;
         <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="as_IfcSurfaceCurveSweptAreaSolid_ReferenceSurface_target_end_upper" value="1"/>
       </ownedEnd>
     </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcVoxelGrid" name="IfcVoxelGrid">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcVoxelGrid_gen_IfcTessellatedItem" general="cl_IfcTessellatedItem"/>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcVoxelGrid_VoxelSizeX" name="VoxelSizeX">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcNonNegativeLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcVoxelGrid_VoxelSizeX_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcVoxelGrid_VoxelSizeX_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcVoxelGrid_VoxelSizeY" name="VoxelSizeY">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcNonNegativeLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcVoxelGrid_VoxelSizeY_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcVoxelGrid_VoxelSizeY_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcVoxelGrid_VoxelSizeZ" name="VoxelSizeZ">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcNonNegativeLengthMeasure"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcVoxelGrid_VoxelSizeZ_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcVoxelGrid_VoxelSizeZ_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcVoxelGrid_NumberOfVoxelsX" name="NumberOfVoxelsX">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveInteger"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcVoxelGrid_NumberOfVoxelsX_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcVoxelGrid_NumberOfVoxelsX_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcVoxelGrid_NumberOfVoxelsY" name="NumberOfVoxelsY">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveInteger"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcVoxelGrid_NumberOfVoxelsY_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcVoxelGrid_NumberOfVoxelsY_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcVoxelGrid_NumberOfVoxelsZ" name="NumberOfVoxelsZ">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcPositiveInteger"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcVoxelGrid_NumberOfVoxelsZ_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcVoxelGrid_NumberOfVoxelsZ_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcVoxelGrid_Voxels" name="Voxels_A[1:?]">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcBoolean"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcVoxelGrid_Voxels_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcVoxelGrid_Voxels_upper" value="1"/>
+      </ownedAttribute>
+    </packagedElement>
   </packagedElement>
 </uml:Model>

--- a/schemas/IfcGeometricModelResource.uml
+++ b/schemas/IfcGeometricModelResource.uml
@@ -1235,7 +1235,7 @@ END_FUNCTION;
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcVoxelGrid_NumberOfVoxelsZ_lower" value="1"/>
         <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcVoxelGrid_NumberOfVoxelsZ_upper" value="1"/>
       </ownedAttribute>
-      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcVoxelGrid_Voxels" name="Voxels_A[1:?]">
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcVoxelGrid_Voxels" name="Voxels_A[1:NumberOfVoxelsX*NumberOfVoxelsY*NumberOfVoxelsZ]">
         <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcBoolean"/>
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcVoxelGrid_Voxels_lower" value="1"/>
         <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcVoxelGrid_Voxels_upper" value="1"/>

--- a/schemas/IfcGeometryResource.uml
+++ b/schemas/IfcGeometryResource.uml
@@ -2981,5 +2981,36 @@ AND
         <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="as_IfcSegmentedReferenceCurve_EndPoint_target_end_upper" value="1"/>
       </ownedEnd>
     </packagedElement>
+    <packagedElement xmi:type="uml:Constraint" xmi:id="ct_IfcListToExpandedArray" name="IfcListToExpandedArray">
+      <specification xmi:type="uml:OpaqueExpression" xmi:id="ct_IfcListToExpandedArray_expr" name="IfcListToExpandedArray">
+        <language>EXPRESS_FUNCTION</language>
+        <body>FUNCTION IfcListToExpandedArray
+(Lis : LIST [0:?] OF GENERIC : T;
+      Low, U : INTEGER;
+      Condition : ARRAY OF BOOLEAN) : ARRAY OF OPTIONAL GENERIC : T;
+  LOCAL
+    LisIndex : INTEGER := Low;
+    Res : ARRAY [Low:U] OF OPTIONAL GENERIC : T;
+  END_LOCAL;
+      
+  IF (SIZEOF(QUERY(item &lt;* Condition | item)) &lt;> SIZEOF(Lis)) THEN
+    RETURN(?);
+  END_IF;
+
+  IF (SIZEOF(Lis) &lt;> (U-Low + 1)) THEN
+    RETURN(?);
+  END_IF;
+	  
+  REPEAT i := 1 TO SIZEOF(Condition);
+    IF (Condition[i]) THEN
+      Res[Low + i - 1] := Lis[LisIndex];
+      LisIndex := LisIndex + 1;
+    END_IF;
+  END_REPEAT;
+  RETURN(Res);
+END_FUNCTION;
+</body>
+      </specification>
+    </packagedElement>
   </packagedElement>
 </uml:Model>

--- a/schemas/IfcProductExtension.uml
+++ b/schemas/IfcProductExtension.uml
@@ -3843,5 +3843,179 @@ AND
     <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Qto_ProjectionElementBaseQuantities_IfcProjectionElement" client="cl_Qto_ProjectionElementBaseQuantities" supplier="cl_IfcProjectionElement"/>
     <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Qto_SiteBaseQuantities_IfcSite" client="cl_Qto_SiteBaseQuantities" supplier="cl_IfcSite"/>
     <packagedElement xmi:type="uml:Dependency" xmi:id="dp_Qto_SpaceBaseQuantities_IfcSpace" client="cl_Qto_SpaceBaseQuantities" supplier="cl_IfcSpace"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcComplementaryData" name="IfcComplementaryData" isAbstract="true">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcComplementaryData_gen_IfcProduct">
+        <general xmi:type="uml:Class" href="IfcKernel.uml#cl_IfcProduct"/>
+      </generalization>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcVoxelData" name="IfcVoxelData" isAbstract="true">
+      <ownedRule xmi:type="uml:Constraint" xmi:id="ct_IfcVoxelData_IsAssignedToProduct" name="IsAssignedToProduct">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="cl_IfcVoxelData_IsAssignedToProduct" name="IsAssignedToProduct">
+          <language>EXPRESS_WHERE</language>
+          <body>EXISTS(SELF\IfcObjectDefinition.HasAssignments)
+AND
+(SIZEOF(SELF\IfcObjectDefinition.HasAssignments) = 1)
+AND
+('IFC4X4.IFCRELASSIGNSTOPRODUCT' IN TYPEOF(SELF\IfcObjectDefinition.HasAssignments[1]))</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:type="uml:Constraint" xmi:id="ct_IfcVoxelData_SameRepresentation" name="SameRepresentation">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="cl_IfcVoxelData_SameRepresentation" name="SameRepresentation">
+          <language>EXPRESS_WHERE</language>
+          <body>SIZEOF(QUERY(ShapeRep &lt;* SELF\IfcObjectDefinition.HasAssignments[1]\IfcRelAssignsToProduct.RelatingProduct\IfcProduct.Representation.Representations |
+ShapeRep = SELF\IfcProduct.Representation.Representations[1])) = 1</body>
+        </specification>
+      </ownedRule>
+      <ownedRule xmi:type="uml:Constraint" xmi:id="ct_IfcVoxelData_VoxelGridRepresentation" name="VoxelGridRepresentation">
+        <specification xmi:type="uml:OpaqueExpression" xmi:id="cl_IfcVoxelData_VoxelGridRepresentation" name="VoxelGridRepresentation">
+          <language>EXPRESS_WHERE</language>
+          <body>EXISTS(SELF\IfcProduct.Representation)
+AND
+(SIZEOF(QUERY(ShapeRep &lt;* SELF\IfcProduct.Representation.Representations | 
+    (SIZEOF(ShapeRep.Items) = 1)
+    AND
+    ('IFC4X4.IFCVOXELGRID' IN TYPEOF(ShapeRep.Items[1])))) = 1)</body>
+        </specification>
+      </ownedRule>
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcVoxelData_gen_IfcComplementaryData" general="cl_IfcComplementaryData"/>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcVoxelData_ValueType" name="ValueType">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcVoxelData_ValueType_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcVoxelData_ValueType_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcVoxelData_GridSize" name="GridSize" isDerived="true">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcInteger"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcVoxelData_GridSize_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcVoxelData_GridSize_upper" value="1"/>
+        <defaultValue xmi:type="uml:OpaqueExpression" xmi:id="at_IfcVoxelData_GridSize_expr" name="GridSize">
+          <language>EXPRESS</language>
+          <body>IfcInteger := SIZEOF(SELF\IfcProduct.Representation.Representations[1].Items[1]\IfcVoxelGrid.Voxels)</body>
+        </defaultValue>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcIntegerVoxelData" name="IfcIntegerVoxelData">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcIntegerVoxelData_gen_IfcVoxelData" general="cl_IfcVoxelData"/>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcIntegerVoxelData_ValueData" name="ValueData_L[1:?]">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcInteger"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcIntegerVoxelData_ValueData_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcIntegerVoxelData_ValueData_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcIntegerVoxelData_Unit" name="Unit" association="as_IfcIntegerVoxelData_Unit">
+        <type xmi:type="uml:Class" href="IfcMeasureResource.uml#un_IfcUnit"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcIntegerVoxelData_Unit_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcIntegerVoxelData_Unit_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcIntegerVoxelData_Values" name="Values" isDerived="true">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcInteger"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcIntegerVoxelData_Values_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcIntegerVoxelData_Values_upper" value="1"/>
+        <defaultValue xmi:type="uml:OpaqueExpression" xmi:id="at_IfcIntegerVoxelData_Values_expr" name="Values">
+          <language>EXPRESS</language>
+          <body>ARRAY [1:SELF\IfcVoxelData.GridSize] OF OPTIONAL IfcInteger := IfcListToExpandedArray(ValueData,1,SELF\IfcVoxelData.GridSize,SELF\IfcProduct.Representation.Representations[1].Items[1]\IfcVoxelGrid.Voxels)</body>
+        </defaultValue>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcLabelVoxelData" name="IfcLabelVoxelData">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcLabelVoxelData_gen_IfcVoxelData" general="cl_IfcVoxelData"/>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcLabelVoxelData_ValueData" name="ValueData_L[1:?]">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcLabelVoxelData_ValueData_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcLabelVoxelData_ValueData_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcLabelVoxelData_Values" name="Values" isDerived="true">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLabel"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcLabelVoxelData_Values_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcLabelVoxelData_Values_upper" value="1"/>
+        <defaultValue xmi:type="uml:OpaqueExpression" xmi:id="at_IfcLabelVoxelData_Values_expr" name="Values">
+          <language>EXPRESS</language>
+          <body>ARRAY [1:SELF\IfcVoxelData.GridSize] OF OPTIONAL IfcLabel := IfcListToExpandedArray(ValueData,1,SELF\IfcVoxelData.GridSize,SELF\IfcProduct.Representation.Representations[1].Items[1]\IfcVoxelGrid.Voxels)</body>
+        </defaultValue>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcLogicalVoxelData" name="IfcLogicalVoxelData">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcLogicalVoxelData_gen_IfcVoxelData" general="cl_IfcVoxelData"/>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcLogicalVoxelData_ValueData" name="ValueData_L[1:?]">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLogical"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcLogicalVoxelData_ValueData_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcLogicalVoxelData_ValueData_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcLogicalVoxelData_Values" name="Values" isDerived="true">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcLogical"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcLogicalVoxelData_Values_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcLogicalVoxelData_Values_upper" value="1"/>
+        <defaultValue xmi:type="uml:OpaqueExpression" xmi:id="at_IfcLogicalVoxelData_Values_expr" name="Values">
+          <language>EXPRESS</language>
+          <body>ARRAY [1:SELF\IfcVoxelData.GridSize] OF OPTIONAL IfcLogical := IfcListToExpandedArray(ValueData,1,SELF\IfcVoxelData.GridSize,SELF\IfcProduct.Representation.Representations[1].Items[1]\IfcVoxelGrid.Voxels)</body>
+        </defaultValue>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcRealVoxelData" name="IfcRealVoxelData">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcRealVoxelData_gen_IfcVoxelData" general="cl_IfcVoxelData"/>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcRealVoxelData_ValueData" name="ValueData_L[1:?]">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcReal"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcRealVoxelData_ValueData_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcRealVoxelData_ValueData_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcRealVoxelData_Unit" name="Unit" association="as_IfcRealVoxelData_Unit">
+        <type xmi:type="uml:Class" href="IfcMeasureResource.uml#un_IfcUnit"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcRealVoxelData_Unit_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcRealVoxelData_Unit_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcRealVoxelData_Values" name="Values" isDerived="true">
+        <type xmi:type="uml:DataType" href="IfcMeasureResource.uml#dt_IfcReal"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcRealVoxelData_Values_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcRealVoxelData_Values_upper" value="1"/>
+        <defaultValue xmi:type="uml:OpaqueExpression" xmi:id="at_IfcRealVoxelData_Values_expr" name="Values">
+          <language>EXPRESS</language>
+          <body>ARRAY [1:SELF\IfcVoxelData.GridSize] OF OPTIONAL IfcReal := IfcListToExpandedArray(ValueData,1,SELF\IfcVoxelData.GridSize,SELF\IfcProduct.Representation.Representations[1].Items[1]\IfcVoxelGrid.Voxels)</body>
+        </defaultValue>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcVectorVoxelData" name="IfcVectorVoxelData">
+      <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcVectorVoxelData_gen_IfcVoxelData" general="cl_IfcVoxelData"/>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcVectorVoxelData_ValueData" name="ValueData_L[1:?]" association="as_IfcVectorVoxelData_ValueData">
+        <type xmi:type="uml:Class" href="IfcGeometryResource.uml#cl_IfcVector"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcVectorVoxelData_ValueData_lower" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcVectorVoxelData_ValueData_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcVectorVoxelData_Unit" name="Unit" association="as_IfcVectorVoxelData_Unit">
+        <type xmi:type="uml:Class" href="IfcMeasureResource.uml#un_IfcUnit"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcVectorVoxelData_Unit_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcVectorVoxelData_Unit_upper" value="1"/>
+      </ownedAttribute>
+      <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcVectorVoxelData_Values" name="Values" isDerived="true">
+        <type xmi:type="uml:Class" href="IfcGeometryResource.uml#cl_IfcVector"/>
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcVectorVoxelData_Values_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcVectorVoxelData_Values_upper" value="1"/>
+        <defaultValue xmi:type="uml:OpaqueExpression" xmi:id="at_IfcVectorVoxelData_Values_expr" name="Values">
+          <language>EXPRESS</language>
+          <body>ARRAY [1:SELF\IfcVoxelData.GridSize] OF OPTIONAL IfcVector := IfcListToExpandedArray(ValueData,1,SELF\IfcVoxelData.GridSize,SELF\IfcProduct.Representation.Representations[1].Items[1]\IfcVoxelGrid.Voxels)</body>
+        </defaultValue>
+      </ownedAttribute>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="as_IfcIntegerVoxelData_Unit" name="Unit" memberEnd="at_IfcIntegerVoxelData_Unit as_IfcIntegerVoxelData_Unit_target_end">
+      <ownedEnd xmi:type="uml:Property" xmi:id="as_IfcIntegerVoxelData_Unit_target_end" name="" type="cl_IfcIntegerVoxelData" association="as_IfcIntegerVoxelData_Unit">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="as_IfcIntegerVoxelData_Unit_target_end_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="as_IfcIntegerVoxelData_Unit_target_end_upper" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="as_IfcRealVoxelData_Unit" name="Unit" memberEnd="at_IfcRealVoxelData_Unit as_IfcRealVoxelData_Unit_target_end">
+      <ownedEnd xmi:type="uml:Property" xmi:id="as_IfcRealVoxelData_Unit_target_end" name="" type="cl_IfcRealVoxelData" association="as_IfcRealVoxelData_Unit">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="as_IfcRealVoxelData_Unit_target_end_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="as_IfcRealVoxelData_Unit_target_end_upper" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="as_IfcVectorVoxelData_ValueData" name="ValueData" memberEnd="at_IfcVectorVoxelData_ValueData as_IfcVectorVoxelData_ValueData_target_end">
+      <ownedEnd xmi:type="uml:Property" xmi:id="as_IfcVectorVoxelData_ValueData_target_end" name="" type="cl_IfcVectorVoxelData" association="as_IfcVectorVoxelData_ValueData">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="as_IfcVectorVoxelData_ValueData_target_end_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="as_IfcVectorVoxelData_ValueData_target_end_upper" value="1"/>
+      </ownedEnd>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Association" xmi:id="as_IfcVectorVoxelData_Unit" name="Unit" memberEnd="at_IfcVectorVoxelData_Unit as_IfcVectorVoxelData_Unit_target_end">
+      <ownedEnd xmi:type="uml:Property" xmi:id="as_IfcVectorVoxelData_Unit_target_end" name="" type="cl_IfcVectorVoxelData" association="as_IfcVectorVoxelData_Unit">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="as_IfcVectorVoxelData_Unit_target_end_lower"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="as_IfcVectorVoxelData_Unit_target_end_upper" value="1"/>
+      </ownedEnd>
+    </packagedElement>
   </packagedElement>
 </uml:Model>

--- a/schemas/IfcRepresentationResource.uml
+++ b/schemas/IfcRepresentationResource.uml
@@ -237,6 +237,11 @@ END_FUNCTION;
         Count := SIZEOF(QUERY(temp &lt;* Items | ('IFC4X3_ADD2.IFCMANIFOLDSOLIDBREP' IN TYPEOF(temp))));      
       END;
 
+    'Voxel' :
+      BEGIN
+        Count := SIZEOF(QUERY(temp &lt;* Items | ('IFC4X4.IFCVOXELGRID' IN TYPEOF(temp))));
+      END;
+
     'BoundingBox' :
       BEGIN
         Count := SIZEOF(QUERY(temp &lt;* Items | ('IFC4X3_ADD2.IFCBOUNDINGBOX' IN TYPEOF(temp))));

--- a/schemas/ifc4x3_add2.uml
+++ b/schemas/ifc4x3_add2.uml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="md_ifc4x3_add2" name="ifc4x3_add2">
+  <packagedElement xmi:type="uml:Package" xmi:id="pk_base" name="base">
+    <packagedElement xmi:type="uml:DataType" xmi:id="dt_binary" name="binary"/>
+    <packagedElement xmi:type="uml:DataType" xmi:id="dt_boolean" name="boolean"/>
+    <packagedElement xmi:type="uml:DataType" xmi:id="dt_integer" name="integer"/>
+    <packagedElement xmi:type="uml:DataType" xmi:id="dt_logical" name="logical"/>
+    <packagedElement xmi:type="uml:DataType" xmi:id="dt_number" name="number"/>
+    <packagedElement xmi:type="uml:DataType" xmi:id="dt_real" name="real"/>
+    <packagedElement xmi:type="uml:DataType" xmi:id="dt_string" name="string"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="cl_PropertyTableValueBase" name="PropertyTableValueBase"/>
+  </packagedElement>
   <packageImport xmi:type="uml:PackageImport" xmi:id="ip_IfcGeometryResource">
     <importedPackage xmi:type="uml:Package" href="IfcGeometryResource.uml#pk_IfcGeometryResource"/>
   </packageImport>
@@ -129,14 +139,4 @@
   <packageImport xmi:type="uml:PackageImport" xmi:id="ip_propertytypes">
     <importedPackage xmi:type="uml:Package" href="propertytypes.uml#pk_propertytypes"/>
   </packageImport>
-  <packagedElement xmi:type="uml:Package" xmi:id="pk_base" name="base">
-    <packagedElement xmi:type="uml:DataType" xmi:id="dt_binary" name="binary"/>
-    <packagedElement xmi:type="uml:DataType" xmi:id="dt_boolean" name="boolean"/>
-    <packagedElement xmi:type="uml:DataType" xmi:id="dt_integer" name="integer"/>
-    <packagedElement xmi:type="uml:DataType" xmi:id="dt_logical" name="logical"/>
-    <packagedElement xmi:type="uml:DataType" xmi:id="dt_number" name="number"/>
-    <packagedElement xmi:type="uml:DataType" xmi:id="dt_real" name="real"/>
-    <packagedElement xmi:type="uml:DataType" xmi:id="dt_string" name="string"/>
-    <packagedElement xmi:type="uml:Class" xmi:id="cl_PropertyTableValueBase" name="PropertyTableValueBase"/>
-  </packagedElement>
 </uml:Model>


### PR DESCRIPTION
**NB: Due to the introduction of IfcComplementaryData, this PR overlaps with TM20 and will likely conflict when merging**



Description: "Introduced a new representation item as well as product data for voxels"

Scope: "ENTITY IfcIntegerVoxelData, ENTITY IfcLabelVoxelData, ENTITY IfcLogicalVoxelData, ENTITY IfcRealVoxelData, ENTITY IfcVectorVoxelData, ENTITY IfcVoxelData, ENTITY IfcVoxelGrid, FUNCTION IfcListToExpandedArray, FUNCTION IfcShapeRepresentationTypes"



<img width="1724" height="578" alt="tm27" src="https://github.com/user-attachments/assets/20413b18-27ca-4b1c-9e94-e5baed51ec71" />

### Documentation preview (only for new/modified entities, cross-links to other pages disabled)

https://ifc44-docs.geerthesselink.com/IFC/PREVIEW/PR-1110/

- [IfcVoxelGrid](https://ifc44-docs.geerthesselink.com/IFC/PREVIEW/PR-1110/lexical/IfcVoxelGrid.html)
- [IfcVoxelData](https://ifc44-docs.geerthesselink.com/IFC/PREVIEW/PR-1110/lexical/IfcVoxelData.html)
- [IfcIntegerVoxelData](https://ifc44-docs.geerthesselink.com/IFC/PREVIEW/PR-1110/lexical/IfcIntegerVoxelData.html)
- [IfcRealVoxelData](https://ifc44-docs.geerthesselink.com/IFC/PREVIEW/PR-1110/lexical/IfcRealVoxelData.html)
- [IfcLabelVoxelData](https://ifc44-docs.geerthesselink.com/IFC/PREVIEW/PR-1110/lexical/IfcLabelVoxelData.html)
- [IfcLogicalVoxelData](https://ifc44-docs.geerthesselink.com/IFC/PREVIEW/PR-1110/lexical/IfcLogicalVoxelData.html)
- [IfcVectorVoxelData](https://ifc44-docs.geerthesselink.com/IFC/PREVIEW/PR-1110/lexical/IfcVectorVoxelData.html)
- [IfcComplementaryData](https://ifc44-docs.geerthesselink.com/IFC/PREVIEW/PR-1110/lexical/IfcComplementaryData.html)