### PR TITLE
[TM12] Attaching colours to tessellations

### DIFF
--- a/docs/schemas/resource/IfcGeometricModelResource/Entities/IfcTessellatedFaceSet.md
+++ b/docs/schemas/resource/IfcGeometricModelResource/Entities/IfcTessellatedFaceSet.md
@@ -33,8 +33,5 @@ An ordered list of Cartesian points used by the coordinate index defined at the 
 ### Dim
 The space dimensionality of this geometric representation item, it is always 3.
 
-### HasColours
-Reference to the indexed colour map providing the corresponding colour RGB values to the faces of the subtypes of _IfcTessellatedFaceSet_.
-
 ### HasTextures
 Reference to the indexed texture map providing the corresponding texture coordinates to the vertices bounding the faces of the subtypes of _IfcTessellatedFaceSet_.

--- a/docs/schemas/resource/IfcGeometricModelResource/Entities/IfcTessellatedItem.md
+++ b/docs/schemas/resource/IfcGeometricModelResource/Entities/IfcTessellatedItem.md
@@ -4,3 +4,8 @@ The _IfcTessellatedItem_ is the abstract supertype of all tessellated geometric 
 <!-- end of short definition -->
 
 > HISTORY New entity in IFC4.
+
+## Attributes
+
+### HasColours
+Reference to the indexed colour map providing the corresponding colour RGB values to the faces of the subtypes of _IfcTessellatedFaceSet_.

--- a/schemas/IfcPresentationAppearanceResource.uml
+++ b/schemas/IfcPresentationAppearanceResource.uml
@@ -351,7 +351,7 @@ END_FUNCTION;
         <general xmi:type="uml:Class" href="IfcPresentationDefinitionResource.uml#cl_IfcPresentationItem"/>
       </generalization>
       <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcIndexedColourMap_MappedTo" name="MappedTo" association="as_IfcIndexedColourMap_MappedTo">
-        <type xmi:type="uml:Class" href="IfcGeometricModelResource.uml#cl_IfcTessellatedFaceSet"/>
+        <type xmi:type="uml:Class" href="IfcGeometricModelResource.uml#cl_IfcTessellatedItem"/>
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcIndexedColourMap_MappedTo_lower" value="1"/>
         <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="at_IfcIndexedColourMap_MappedTo_upper" value="1"/>
       </ownedAttribute>


### PR DESCRIPTION
Description: "IfcIndexedColourMap.MappedTo type changed from IfcTessellatedFaceSet to IfcTessellatedItem (more abstract). Appropriate changes were made to the corresponding inverses."
Scope: "ENTITY IfcIndexedColourMap, ENTITY IfcTessellatedItem, ENTITY IfcTessellatedFaceSet, ENTITY IfcIndexedPolygonalFace, ENTITY IfcIndexedPolygonalFaceWithVoids"

before:

<img width="790" height="344" alt="tm12_before" src="https://github.com/user-attachments/assets/f1c62411-3d8a-488a-bf78-427b7b3955e8" />

after:

<img width="1001" height="344" alt="tm12_after" src="https://github.com/user-attachments/assets/856b0c73-08e4-4e11-9a89-8354a356bf7d" />
