### PR TITLE
Clarify Helmert Transition Segment CT by removing unnecessary details

### DIFF
--- a/docs/templates/Partial Templates/Geometry/Curve Segment Geometry/Helmert Transition Segment/README.md
+++ b/docs/templates/Partial Templates/Geometry/Curve Segment Geometry/Helmert Transition Segment/README.md
@@ -12,8 +12,6 @@ QuadraticTerm =  -L/√2
 LinearTerm = L/4
 Constant = -1
 
-_SegmentStart_ is the bearing angle at start and _SegmentLength_ is the bearing angle at the end of the segment.
-
 ```
 concept {
     IfcCurveSegment:ParentCurve -> IfcSecondOrderPolynomialSpiral


### PR DESCRIPTION
closes buildingSMART/IFC4.x-IF#152
Removed explanation of SegmentStart and SegmentLength.