### PR TITLE
[TM23] Geoscience - deprecations

### DIFF
--- a/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeomodel.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeomodel.md
@@ -6,3 +6,5 @@ Representation of the concept of a volumetric geological and geotechnical model,
 The assembly may contain one of more strata and other anthropic elements. The contained subtypes of _IfcGeotechnicalStratum_ will have shape representations made from polyhedra or surfaces if a 'Yabuki' top surface model is being used.
 
 > NOTE This IfcElement subtype is an anomaly in the sense that it does not have a PredefinedType attribute. This is to be provided in subsequent versions of the standard.
+
+> DEPRECATION The entity _IfcGeomodel_ shall not be used anymore, use _IfcGeoScienceModel_ instead.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeomodel.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeomodel.md
@@ -7,4 +7,4 @@ The assembly may contain one of more strata and other anthropic elements. The co
 
 > NOTE This IfcElement subtype is an anomaly in the sense that it does not have a PredefinedType attribute. This is to be provided in subsequent versions of the standard.
 
-> DEPRECATION The entity _IfcGeomodel_ shall not be used anymore, use _IfcGeoScienceModel_ instead.
+> IFC4.4.0.0 DEPRECATION This entity is now deprecated. Use IfcGeoScienceModel instead.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeoslice.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeoslice.md
@@ -5,4 +5,4 @@ Representation of the concept of a sectional planar geological and geotechnical 
 
 > NOTE This IfcElement subtype is an anomaly in the sense that it does not have a PredefinedType attribute. This is to be provided in subsequent versions of the standard.
 
-> DEPRECATION The entity _IfcGeoSlice_ shall not be used anymore, use _IfcGeoScienceModel_ instead.
+> IFC4.4.0.0 DEPRECATION This entity is now deprecated. Use IfcGeoScienceModel instead.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeoslice.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeoslice.md
@@ -4,3 +4,5 @@ Representation of the concept of a sectional planar geological and geotechnical 
 <!-- end of short definition -->
 
 > NOTE This IfcElement subtype is an anomaly in the sense that it does not have a PredefinedType attribute. This is to be provided in subsequent versions of the standard.
+
+> DEPRECATION The entity _IfcGeoSlice_ shall not be used anymore, use _IfcGeoScienceModel_ instead.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalAssembly.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalAssembly.md
@@ -7,4 +7,4 @@ Use of an assembly is optional but can carry the methodology and uncertainty inf
 Such assemblies will include _IfcGeotechnicalStratum_ entity types and may include other entity types such as _IfcPile_, _IfcSlab_ or _IfcSensor_ to represent the capping, lining or logging equipment present.
 _IfcBorehole_ or _IfcGeoslice_ can have a physical reality as a construction hazard alongside being the carrier for the interpreted results. Geological hazards may be associated to any _IfcGeotechnicalAssembly_ or _IfcGeotechnicalStratum_.
 
-> DEPRECATION The entity _IfcGeotechnicalAssembly_ shall not be used anymore, use _IfcGeoScienceModel_ instead.
+> IFC4.4.0.0 DEPRECATION This entity is now deprecated. Use IfcGeoScienceModel instead.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalAssembly.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalAssembly.md
@@ -6,3 +6,5 @@ Representation of the abstract concept of a geological and geotechnical model, u
 Use of an assembly is optional but can carry the methodology and uncertainty information.
 Such assemblies will include _IfcGeotechnicalStratum_ entity types and may include other entity types such as _IfcPile_, _IfcSlab_ or _IfcSensor_ to represent the capping, lining or logging equipment present.
 _IfcBorehole_ or _IfcGeoslice_ can have a physical reality as a construction hazard alongside being the carrier for the interpreted results. Geological hazards may be associated to any _IfcGeotechnicalAssembly_ or _IfcGeotechnicalStratum_.
+
+> DEPRECATION The entity _IfcGeotechnicalAssembly_ shall not be used anymore, use _IfcGeoScienceModel_ instead.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalElement.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalElement.md
@@ -3,7 +3,7 @@
 Abstract supertype for geotechnical entities.
 <!-- end of short definition -->
 
-> DEPRECATION The entity _IfcGeotechnicalElement_ shall not be used anymore, use _IfcGeoScienceElement_ instead.
+> IFC4.4.0.0 DEPRECATION This entity is now deprecated. Use IfcGeoScienceElement instead.
 
 ## Concepts
 

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalElement.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalElement.md
@@ -3,6 +3,8 @@
 Abstract supertype for geotechnical entities.
 <!-- end of short definition -->
 
+> DEPRECATION The entity _IfcGeotechnicalElement_ shall not be used anymore, use _IfcGeoScienceElement_ instead.
+
 ## Concepts
 
 ### Earthworks Cuttings

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalStratum.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalStratum.md
@@ -5,4 +5,4 @@ Representation of the concept of an identified discrete almost homogeneous geolo
 
 The shape representations used should correspond to the sub-type of _IfcGeotechnicalAssembly_ in which it occurs
 
-> DEPRECATION The entity _IfcGeotechnicalstratum_ shall not be used anymore, use _IfcGeoScienceFeature_ instead.
+> IFC4.4.0.0 DEPRECATION This entity is now deprecated. Use IfcGeoScienceFeature instead.

--- a/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalStratum.md
+++ b/docs/schemas/shared/IfcSharedInfrastructureElements/Entities/IfcGeotechnicalStratum.md
@@ -4,3 +4,5 @@ Representation of the concept of an identified discrete almost homogeneous geolo
 <!-- end of short definition -->
 
 The shape representations used should correspond to the sub-type of _IfcGeotechnicalAssembly_ in which it occurs
+
+> DEPRECATION The entity _IfcGeotechnicalstratum_ shall not be used anymore, use _IfcGeoScienceFeature_ instead.

--- a/schemas/IfcSharedInfrastructureElements.uml
+++ b/schemas/IfcSharedInfrastructureElements.uml
@@ -81,6 +81,9 @@
       <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="en_IfcSignalTypeEnum_NOTDEFINED" name="NOTDEFINED"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcGeotechnicalElement" name="IfcGeotechnicalElement" isAbstract="true">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_bMj8EF9mEfG73IEoZuhExg">
+        <body>DEPRECATED</body>
+      </ownedComment>
       <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcGeotechnicalElement_gen_IfcElement">
         <general xmi:type="uml:Class" href="IfcProductExtension.uml#cl_IfcElement"/>
       </generalization>

--- a/schemas/IfcSharedInfrastructureElements.uml
+++ b/schemas/IfcSharedInfrastructureElements.uml
@@ -109,6 +109,9 @@
       </generalization>
     </packagedElement>
     <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcGeotechnicalAssembly" name="IfcGeotechnicalAssembly" isAbstract="true">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_Ac9dAF9SEfG73IEoZuhExg">
+        <body>DEPRECATED</body>
+      </ownedComment>
       <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcGeotechnicalAssembly_gen_IfcGeotechnicalElement" general="cl_IfcGeotechnicalElement"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcGeotechnicalStratum" name="IfcGeotechnicalStratum">

--- a/schemas/IfcSharedInfrastructureElements.uml
+++ b/schemas/IfcSharedInfrastructureElements.uml
@@ -177,6 +177,9 @@
       </ownedAttribute>
     </packagedElement>
     <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcGeomodel" name="IfcGeomodel">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_T1irMF9mEfG73IEoZuhExg">
+        <body>DEPRECATED</body>
+      </ownedComment>
       <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcGeomodel_gen_IfcGeotechnicalAssembly" general="cl_IfcGeotechnicalAssembly"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcGeoslice" name="IfcGeoslice">

--- a/schemas/IfcSharedInfrastructureElements.uml
+++ b/schemas/IfcSharedInfrastructureElements.uml
@@ -183,6 +183,9 @@
       <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcGeomodel_gen_IfcGeotechnicalAssembly" general="cl_IfcGeotechnicalAssembly"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcGeoslice" name="IfcGeoslice">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_NZvFYF9mEfG73IEoZuhExg">
+        <body>DEPRECATED</body>
+      </ownedComment>
       <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcGeoslice_gen_IfcGeotechnicalAssembly" general="cl_IfcGeotechnicalAssembly"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcReinforcedSoil" name="IfcReinforcedSoil">

--- a/schemas/IfcSharedInfrastructureElements.uml
+++ b/schemas/IfcSharedInfrastructureElements.uml
@@ -118,6 +118,9 @@
       <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcGeotechnicalAssembly_gen_IfcGeotechnicalElement" general="cl_IfcGeotechnicalElement"/>
     </packagedElement>
     <packagedElement xmi:type="uml:Class" xmi:id="cl_IfcGeotechnicalStratum" name="IfcGeotechnicalStratum">
+      <ownedComment xmi:type="uml:Comment" xmi:id="_iNUCAF9mEfG73IEoZuhExg">
+        <body>DEPRECATED</body>
+      </ownedComment>
       <generalization xmi:type="uml:Generalization" xmi:id="cl_IfcGeotechnicalStratum_gen_IfcGeotechnicalElement" general="cl_IfcGeotechnicalElement"/>
       <ownedAttribute xmi:type="uml:Property" xmi:id="at_IfcGeotechnicalStratum_PredefinedType" name="PredefinedType" type="en_IfcGeotechnicalStratumTypeEnum">
         <lowerValue xmi:type="uml:LiteralInteger" xmi:id="at_IfcGeotechnicalStratum_PredefinedType_lower"/>


### PR DESCRIPTION
<img width="2086" height="882" alt="tm23" src="https://github.com/user-attachments/assets/fc29a97f-9aff-4a15-ae9b-a0e23ccc663c" />

Description: "Joint with point 22 above, some existing entities were deprecated."
Scrope: "ENTITY IfcGeomodel, ENTITY IfcGeoslice, ENTITY IfcGeotechnicalAssembly, ENTITY IfcGeotechnicalElement, ENTITY IfcGeotechnicalStratum, TYPE IfcGeotechnicalStratumTypeEnum"

(Personal note: seems drastic to deprecate such a large tree of elements with associated property sets. Have all these psets/qsets been reviewed so that their semantics have found a new place? For export, deprecation essentially means deletion, the compatibility folks are not going to like this. I think there needs to be more guidance on how to migrate. Just a statement to use IfcGeoScienceModel/-Element/-Feature seems insufficient.)