### PR TITLE
[TC22] Voxel Geometry

### DIFF
--- a/docs/templates/Product Shape/Product Geometric Representation/Voxel Geometry/README.md
+++ b/docs/templates/Product Shape/Product Geometric Representation/Voxel Geometry/README.md
@@ -1,0 +1,25 @@
+Voxel Geometry
+===================
+
+
+
+```
+concept {
+    IfcProduct:Representation -> IfcProductDefinitionShape
+    IfcProductDefinitionShape:Representations -> IfcShapeRepresentation
+    IfcShapeRepresentation:RepresentationIdentifier -> IfcLabel_0
+    IfcShapeRepresentation:ContextOfItems -> IfcGeometricRepresentationContext
+    IfcShapeRepresentation:RepresentationType -> IfcLabel_1
+    IfcShapeRepresentation:Items -> IfcVoxelGrid
+    IfcVoxelGrid:HasColours -> IfcIndexedColourMap:MappedTo
+    IfcIndexedColourMap:Colours -> IfcColourRgbList:ColourList
+    IfcColourRgbList:ColourList -> IfcNormalisedRatioMeasure
+    IfcLabel_0 -> constraint_0
+    constraint_0[label="=Body"]
+    IfcLabel_1 -> constraint_1
+    constraint_1[label="=Voxel"]
+    IfcShapeRepresentation:RepresentationIdentifier[binding="Identifier"]
+    IfcShapeRepresentation:RepresentationType[binding="Type"]
+    IfcShapeRepresentation:Items[binding="Items"]
+}
+```

--- a/docs/templates/Product Shape/Product Geometric Representation/Voxel Geometry/README.md
+++ b/docs/templates/Product Shape/Product Geometric Representation/Voxel Geometry/README.md
@@ -14,6 +14,12 @@ concept {
     IfcVoxelGrid:HasColours -> IfcIndexedColourMap:MappedTo
     IfcIndexedColourMap:Colours -> IfcColourRgbList:ColourList
     IfcColourRgbList:ColourList -> IfcNormalisedRatioMeasure
+    IfcIndexedColourMap:MappedTo -> IfcTessellatedItem:HasColours
+
+    IfcProduct:ReferencedBy -> IfcRelAssignsToProduct:RelatingProduct
+    IfcRelAssignsToProduct:RelatedObjects -> IfcVoxelData:HasAssignments
+    IfcRelAssignsToProduct:RelatedObjects[binding="Type"]
+    IfcVoxelData:Representation -> IfcProductDefinitionShape
     IfcLabel_0 -> constraint_0
     constraint_0[label="=Body"]
     IfcLabel_1 -> constraint_1


### PR DESCRIPTION
Add concept templates for Voxel Geometry

Source:
<img width="1384" height="352" alt="image" src="https://github.com/user-attachments/assets/ce76457e-c201-43ff-a5a5-8026fd14537e" />

New: (incomplete rendering of new entity IfcVoxelGrid)
<img width="3223" height="1214" alt="image" src="https://github.com/user-attachments/assets/af292b73-ca23-4a2c-895a-de2e8fdd85e4" />

With [ED] additions:
<img width="3072" height="902" alt="image" src="https://github.com/user-attachments/assets/51f3a2a6-7429-4033-bde3-75d44731bc4f" />

