### PR TITLE
Removes reference to non-existent concept template "Alignment Geometry - Reusing Horizontal Layout" from IfcAlignment

### DIFF
--- a/docs/schemas/core/IfcProductExtension/Entities/IfcAlignment.md
+++ b/docs/schemas/core/IfcProductExtension/Entities/IfcAlignment.md
@@ -86,7 +86,7 @@ These 3 layouts may be used in different configurations. The most common are:
 4. Multiple Vertical layouts based on the same Horizontal Layout
 5. Multiple Vertical layouts based on the same Horizontal Layout, with a Cant layout applied
 
-(4) and (5) are used in scenarios where multiple alignments re-use the same horizontal layout definition. See **Alignment Layout - Reusing Horizontal Layout** and **Alignment Geometry - Reusing Horizontal Layout** for details on how to relate parent and child alignments in these cases.
+(4) and (5) are used in scenarios where multiple alignments re-use the same horizontal layout definition. See **Alignment Layout - Reusing Horizontal Layout** for details on how to relate parent and child alignments in these cases.
 
 ![Alignment configurations](../../../../figures/IfcAlignment-possible-configurations.png)
 


### PR DESCRIPTION
The Concept usage section of IfcAlignment, for Alignment Layouts, references "Alignment Geometry - Reusing Horizontal Layout". This concept template does not exist. This PR deletes the reference.