### PR TITLE
Updates documentation for IfcPositioningElement

### DIFF
--- a/docs/schemas/core/IfcProductExtension/Entities/IfcPositioningElement.md
+++ b/docs/schemas/core/IfcProductExtension/Entities/IfcPositioningElement.md
@@ -1,6 +1,7 @@
 # IfcPositioningElement
 
-New and abstract entity definition for positioning and annotating elements that are used to position other elements relatively.
+An abstract entity definition used to position other elements.
+
 <!-- end of short definition -->
 
 > EXAMPLE A grid is a positioning element to position building components mainly in vertical structures, an alignment is a linear positioning element to position geographic and civil elements mainly in infrastructure works.
@@ -18,9 +19,9 @@ Relationship to a spatial structure element, to which the positioning element is
 > IFC4 CHANGE The inverse relationship has been promoted from _IfcGrid_ to this new supertype with upward compatibility
 
 ### Positions
-
+Relationship to a product which is positioned by this positioning element.
 
 ## Formal Propositions
 
 ### HasPlacement
-The placement for the grid has to be given.
+The ObjectPlacement is required.


### PR DESCRIPTION
closes #1005 

RP to resolve discussion at https://github.com/buildingSMART/IFC4.x-development/issues/1005

1. The first sentence should be revised to "An abstract entity definition for positioning and annotating elements that are used to position other elements relatively.". The word "New" is unnecessary. At what point does this entity cease to be "new"? The change log indicates IfcPositionElement was new in IFC 4.1
2. <s>The abstract icon is missing</s> **(done)**
3. The formal proposition clearly states that ObjectPlacement is required for grid. This should be changed to “ObjectPlacement is required”.
4. <s>HTML markup to be removed from the description</s> **(done)**
5. Add description for _Positions_