### PR TITLE
Updates IfcOpenCrossProfileDef documentation

### DIFF
--- a/docs/schemas/resource/IfcProfileResource/Entities/IfcOpenCrossProfileDef.md
+++ b/docs/schemas/resource/IfcProfileResource/Entities/IfcOpenCrossProfileDef.md
@@ -20,6 +20,10 @@ The slope measure.
 
 ### Tags
 
+OPTIONAL LIST [2:?] OF UNIQUE IfcLabel
+
+When used with _IfcSectionedSurface_, the Tag attribute is used to define interpolation transion curves and branching longitudinal breaklines. Within this context, tags must be unique to properly match profile verticies between consecutive cross sections.
+
 ### OffsetPoint
 Optional Cartesian point to nominate the profile curve start. The provided slopes and widths emerge from this point. If no value is given, the profile initiates at the alignment intersection with the profile plane.
 


### PR DESCRIPTION
When creating an IfcSectionedSurface using IfcOpenCrossProfileDef with stringline transition curves or breaklines, Tags must be unique to properly match profile vertices between cross section profiles. If an IfcSectionSurface uses stringline transition curves defined by IfcOffsetCurveByDistances and all the IfcOffsetCurveByDistances.Tag = "A" and IfcOpenCrossProfileDef.Tags is a list of "A", there is no way to know which offset curve is guiding which profile point. Tag uniqueness is required so there is no ambiguity when matching string lines to profile vertices.

@evandroAlfieri this is related to https://github.com/buildingSMART/IFC4.x-development/pull/1021 which I accidentally closed and can't reopen.