### PR TITLE
Fix typo in BreakerUnitFuseBreakingCurve document

### DIFF
--- a/docs/properties/b/BreakerUnitFuseBreakingingCurve.md
+++ b/docs/properties/b/BreakerUnitFuseBreakingingCurve.md
@@ -1,4 +1,4 @@
-BreakerUnitFuseBreakingingCurve
+BreakerUnitFuseBreakingCurve
 ===============================
 
 A curve that establishes the let through breaking energy of a breaker unit when a particular prospective breaking current is applied.  Note that the breaker unit fuse breaking curve is defined within a Cartesian coordinate system and this fact must be:


### PR DESCRIPTION
Corrected the spelling of 'Breakinging' to 'Breaking' in the document title.