### PR TITLE
Various changes to HTML generation

### DIFF
--- a/code/generators/html/__main__.py
+++ b/code/generators/html/__main__.py
@@ -32,6 +32,13 @@ def main() -> None:
         help="Render only a deterministic sample of generated pages. Static pages are always included.",
     )
     parser.add_argument(
+        "--include",
+        nargs="+",
+        default=None,
+        metavar="PAGE",
+        help="Only render generated pages whose paths match one of the given values. Example: --include '/'.",
+    )
+    parser.add_argument(
         "--profile",
         action="store_true",
         help="Run the build under cProfile. This forces in-process rendering so the profile captures real work.",
@@ -41,6 +48,10 @@ def main() -> None:
         type=Path,
         default=None,
         help="Optional path to write the cProfile summary report.",
+    )
+    parser.add_argument(
+        "--no-index",
+        action="store_true"
     )
     args = parser.parse_args()
 
@@ -55,6 +66,8 @@ def main() -> None:
         args.threads,
         args.sample_percent,
         args.profile,
+        include_paths=args.include,
+        no_index=args.no_index
     )
     builder = StaticSiteBuilder(config)
 

--- a/code/generators/html/builder.py
+++ b/code/generators/html/builder.py
@@ -2083,7 +2083,8 @@ class StaticSiteBuilder:
         self._render_html_paths(self._utility_paths(), collect=False, resource_names=resource_names)
 
         self._copy_generated_svgs()
-        self._build_search_index()
+        if not self.config.no_index:
+            self._build_search_index()
 
         return {
             "written": len([path for path in self.config.output_dir.rglob("*") if path.is_file()]),
@@ -2223,6 +2224,20 @@ class StaticSiteBuilder:
             if public_path not in excluded and not public_path.startswith("/annex")
         ]
 
+    def _should_render(self, path: str) -> bool:
+        if self.config.include_paths is None:
+            return True
+
+        normalized = path.strip("/")
+        return any(
+            normalized == include.strip("/")
+            or (
+                include.strip("/")
+                and normalized.startswith(include.strip("/") + "/")
+            )
+            for include in self.config.include_paths
+        )
+
     def _render_html_paths(
         self,
         public_paths: list[str],
@@ -2231,6 +2246,8 @@ class StaticSiteBuilder:
         listing_payloads: dict[str, list[dict[str, str]]] | None = None,
         resource_names: tuple[str, ...],
     ) -> None:
+        public_paths = [p for p in public_paths if self._should_render(p)]
+
         if self.config.profile or self.config.threads == 1:
             for public_path in public_paths:
                 try:

--- a/code/generators/html/builder.py
+++ b/code/generators/html/builder.py
@@ -424,6 +424,13 @@ class StaticTemplateRenderer(markdown_mixin):
         return template.render(self._template_context(**context))
 
     def _template_context(self, **context) -> dict:
+        import version
+        """
+        >>> from matplotlib import cm, colors
+        >>> [colors.to_hex(c) for c in cm.Pastel1.colors][0:3]
+        ['#fbb4ae', '#b3cde3', '#ccebc5']
+        """
+        color = ['#fbb4ae', '#b3cde3', '#ccebc5'][version.status_number]
         payload = {
             "is_iso": False,
             "is_package": False,
@@ -435,6 +442,8 @@ class StaticTemplateRenderer(markdown_mixin):
             "current_lang_slug": slugify("English (default)"),
             "languages": translate.list_languages(),
             "get_page_history": lambda path: page_history(context.get("repo_dir", self.config.repo_root), path),
+            "header_color": color,
+            "status_message": version.status_message,
         }
         payload.update(context)
         return payload

--- a/code/generators/html/builder.py
+++ b/code/generators/html/builder.py
@@ -32,6 +32,7 @@ from .search import SearchIndexBuilder
 from . import translate
 from ..util.xmi_document import SCHEMA_NAME
 from . import md as mdp
+from git_history import page_history
 
 REPO_BRANCH = os.environ.get("REPO_BRANCH", "xmi-refresh")
 REPO_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
@@ -433,6 +434,7 @@ class StaticTemplateRenderer(markdown_mixin):
             "get_language_icon": translate.get_language_icon,
             "current_lang_slug": slugify("English (default)"),
             "languages": translate.list_languages(),
+            "get_page_history": lambda path: page_history(context.get("repo_dir", self.config.repo_root), path),
         }
         payload.update(context)
         return payload
@@ -1909,6 +1911,7 @@ class StaticTemplateRenderer(markdown_mixin):
             navigation=self.get_navigation(),
             content=html,
             path=path.resolve().relative_to(self.examples_repo_root).as_posix(),
+            repo_dir=str(self.examples_repo_root),
             repo="buildingSMART/IFC4.3.x-sample-models",
             branch="main",
             title=self._example_title(Path(example).name),

--- a/code/generators/html/config.py
+++ b/code/generators/html/config.py
@@ -13,6 +13,8 @@ class BuildConfig:
     threads: int = 1
     sample_percent: float = 100.0
     profile: bool = False
+    include_paths: tuple[str, ...] | None = None
+    no_index: bool = False
 
     @classmethod
     def from_repo_root(
@@ -22,6 +24,8 @@ class BuildConfig:
         threads: int | None = None,
         sample_percent: float | None = None,
         profile: bool = False,
+        include_paths: tuple[str, ...] | None = None,
+        no_index: bool = False
     ) -> "BuildConfig":
         repo_root = repo_root.resolve()
         code_dir = (repo_root / "code").resolve()
@@ -38,4 +42,6 @@ class BuildConfig:
             threads=max(1, threads),
             sample_percent=max(0.1, min(100.0, sample_percent)),
             profile=profile,
+            include_paths=include_paths,
+            no_index=no_index
         )

--- a/code/generators/html/refiner.py
+++ b/code/generators/html/refiner.py
@@ -272,7 +272,7 @@ class HtmlRefiner:
             title.string = f"{h1.get_text(strip=True)} - {title.get_text(strip=True)}"
 
     def _normalize_urls(self, soup, public_path: str) -> None:
-        for tag, attr in (("a", "href"), ("img", "src"), ("script", "src"), ("link", "href")):
+        for tag, attr in (("a", "href"), ("img", "src"), ("script", "src"), ("link", "href"), ("form", "action")):
             for element in soup.find_all(tag):
                 if value := element.get(attr):
                     if normalized := self._normalize_url(public_path, value):

--- a/code/git_history.py
+++ b/code/git_history.py
@@ -1,0 +1,114 @@
+import base64
+import hashlib
+from pathlib import Path
+import re
+import subprocess
+from functools import lru_cache
+import html
+from urllib.request import Request, urlopen
+
+_GITHUB_NOREPLY = re.compile(r"^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$")
+
+def _initials(name: str) -> str:
+    parts = re.findall(r"[^\W\d_]+", name, flags=re.UNICODE)
+
+    if len(parts) >= 2:
+        return (parts[0][0] + parts[-1][0]).upper()
+    if parts:
+        return parts[0][:2].upper()
+    return "?"
+
+
+def _initials_avatar(name: str) -> str:
+    initials = html.escape(_initials(name))
+
+    svg = f"""\
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="16" fill="#9ca3af"/>
+  <text x="16" y="16"
+        text-anchor="middle"
+        dominant-baseline="central"
+        font-family="sans-serif"
+        font-size="11"
+        font-weight="600"
+        fill="white">{initials}</text>
+</svg>"""
+
+    encoded = base64.b64encode(svg.encode("utf-8")).decode("ascii")
+    return f"data:image/svg+xml;base64,{encoded}"
+
+
+def _avatar_url(name: str, email: str):
+    match = _GITHUB_NOREPLY.match(email)
+    if match:
+        return f"https://github.com/{match.group(1)}.png?size=32"
+    digest = hashlib.md5(email.strip().lower().encode("utf-8")).hexdigest()
+    # &d=404 means "return 404 if no gravatar exists", which is what we want, so we can fall back to our own initials avatar.
+    gravatar_url = f"https://www.gravatar.com/avatar/{digest}?s=32&d=identicon&d=404"
+
+    try:
+        raise ValueError("")
+        request = Request(gravatar_url, method="HEAD")
+        with urlopen(request, timeout=2):
+            return gravatar_url
+    except BaseException as e:
+        return _initials_avatar(name)
+
+
+@lru_cache(maxsize=None)
+def page_history(repo_dir : Path | str | None, path : str):
+    """Return contributor and last-change data from the checked-out tree."""
+    if not path:
+        return None
+
+    """
+    --format=%aN%x00%aE%x00%aI%x00%B%x00%x1e ── Record Separator (0x1E)
+              │   │  │   │  │   │  |  └──────── NUL
+              │   │  │   │  │   │  └─────────── %B: raw commit message (subject + body)             
+              │   │  │   │  │   └────────────── NUL
+              │   │  │   │  └────────────────── %aI: author date, strict ISO 8601 
+              │   │  │   └───────────────────── NUL
+              │   │  └───────────────────────── %aE: author email, respecting .mailmap
+              │   └──────────────────────────── NUL
+              └──────────────────────────────── %aN: author name, respecting .mailmap
+    """
+
+    result = subprocess.run(
+        [
+            "git", "-C", str(repo_dir), "log", "--follow",
+            "--format=%aN%x00%aE%x00%aI%x00%B%x00%x1e", "--", path,
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    records = []
+    for record in result.stdout.split("\x1e"):
+        fields = record.strip().rstrip("\x00").split("\x00", 3)
+        if len(fields) == 4:
+            name, email, date, message = fields
+            records.append({
+                "name": name,
+                "email": email,
+                "date": date,
+                "message": message.strip(),
+            })
+    if not records:
+        return None
+
+    contributors : dict[str, dict] = {}
+    for commit in records:
+        key = commit["email"].lower()
+        contributor = contributors.setdefault(key, {
+            "name": commit["name"],
+            "avatar_url": _avatar_url(commit["name"], commit["email"]),
+            "commits": 0,
+        })
+        contributor["commits"] += 1
+
+    return {
+        "contributors": sorted(contributors.values(), key=lambda c: c["commits"], reverse=True),
+        "last_change": records[0],
+    }

--- a/code/render_support.py
+++ b/code/render_support.py
@@ -24,6 +24,7 @@ import tabulate
 import pydot
 import pysolr
 import markdown
+from git_history import page_history
 
 import bs4
 
@@ -2646,7 +2647,8 @@ def inject_variables():
         'branch': REPO_BRANCH,
         'get_language_icon': translate.get_language_icon,  
         'current_lang_slug': slugify(request.cookies.get('languagePreference', 'English (default)')),
-        'languages': translate.list_languages()
+        'languages': translate.list_languages(),
+        'get_page_history': lambda path: page_history(REPO_DIR, path)
     }
 
 

--- a/code/templates/main.html
+++ b/code/templates/main.html
@@ -135,8 +135,13 @@
                     </p>
                     <p>
                         <small>
-                            <span id="contributors"></span><br />
-                            <span id="last-change"></span>
+                            {% set page_history = get_page_history(path) %}
+                            {% if page_history %}
+                            <span id="contributors">{{ page_history.contributors|length }} contributor(s):
+                                {% for contributor in page_history.contributors %}<img src="{{ contributor.avatar_url }}" class="contributor-icon" alt="{{ contributor.name }}" title="{{ contributor.name }}">{% endfor %}
+                            </span><br />
+                            <span id="last-change">Last change: <em>{{ page_history.last_change.message }}</em> by {{ page_history.last_change.name }} on {{ page_history.last_change.date }}</span>
+                            {% endif %}
                         </small>
                     </p>
                     <p>

--- a/code/templates/main.html
+++ b/code/templates/main.html
@@ -17,20 +17,15 @@
         <div class="row">
             <header>
                 {% if is_iso %}
-                    <p style='float: right; text-align: right'>International Organization for Standardization</p>
+                    <p class="header-iso-title" style="text-align: right">International Organization for Standardization</p>
                     <p>ISO 16739-1:2023(E)</p>
                 {% else %}
-                    <img class="logo" src="https://raw.githubusercontent.com/buildingSMART/IFC4.x-development/ifc4.4-main/docs/assets/img/IFC4x4-logo1.1-wide.png" width="100" style="
-                        display: inline-flex;
-                        padding-bottom: 0px;
-                        padding-top: 0px;
-                        float: left;
-                    ">
-                    <p style="display: inline-block; vertical-align: top;">{{ spec_version_string_full }} ({{ schema_version_string }})
+                    <img src="https://raw.githubusercontent.com/buildingSMART/IFC4.x-development/ifc4.4-main/docs/assets/img/IFC4x4-logo1.1-wide.png">
+                    <p class="header-title">{{ spec_version_string_full }} ({{ schema_version_string }})
                         {% if is_package %}
                             <small>official</small>
                         {% else %}
-                            <small>under development</small>
+                            <small style="background-color: {{ header_color }};">{{ status_message }}</small>
                         {% endif %}
                     </p>
                 {% endif %}

--- a/code/version.json
+++ b/code/version.json
@@ -1,1 +1,9 @@
-[4,4,0]
+{
+    "version": [4,4,0],
+    "@status-options": {
+        "PREVIEW": "⚠ Preview version - backwards incompatible changes are likely",
+        "DEVELOPMENT": "⚠ Not an official release - under development",
+        "OFFICIAL": "✓ Official release"
+    },
+    "status": "DEVELOPMENT"
+}

--- a/code/version.json
+++ b/code/version.json
@@ -2,7 +2,7 @@
     "version": [4,4,0],
     "@status-options": {
         "PREVIEW": "⚠ Preview version - backwards incompatible changes are likely",
-        "DEVELOPMENT": "⚠ Not an official release - under development",
+        "DEVELOPMENT": "⚠ buildingSMART Working Draft. All content is under development.",
         "OFFICIAL": "✓ Official release"
     },
     "status": "DEVELOPMENT"

--- a/code/version.json
+++ b/code/version.json
@@ -1,5 +1,5 @@
 {
-    "version": [4,4,0],
+    "version": [4,4,0,0],
     "@status-options": {
         "PREVIEW": "⚠ Preview version - backwards incompatible changes are likely",
         "DEVELOPMENT": "⚠ buildingSMART Working Draft. All content is under development.",

--- a/code/version.py
+++ b/code/version.py
@@ -2,7 +2,11 @@ import os
 import json
 import subprocess
 
-version_tuple = json.load(open('version.json'))
+version_dict = json.load(open('version.json', encoding='utf-8'))
+version_tuple = version_dict['version']
+status = version_dict['status']
+status_number = list(version_dict['@status-options'].keys()).index(status)
+status_message = version_dict['@status-options'][status]
 prefixes = ('IFC', 'X', '_ADD', '_TC')
 schema_version_string = ''.join(''.join(map(str, t)) if t[1] else '' for t in zip(prefixes, version_tuple))
 spec_version_string = f'IFC {".".join(map(str, version_tuple))}'

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -14,17 +14,29 @@ html {
      font-size: 0.95rem;
 }
 header {
+    display: flex;
+    align-items: center;
     width: 100%;
     margin-bottom: var(--universal-margin);
 }
 header p {
-    float: left;
+    align-self: center;
+}
+header img {
+    align-self: flex-end;
+    height: 100%;
+    width: auto;
+    box-shadow: none !important;
 }
 ul {
     list-style-type: "\2014\a0";
 }
 header ul {
-    float: right;
+    margin-left: auto;
+    align-self: center;
+}
+header .header-iso-title {
+    margin-left: auto;
 }
 header ul>li {
     display: inline-block;
@@ -900,4 +912,9 @@ body.cover.iso #main-content * {
 
 .rightpanel div {
     pointer-events: auto;
+}
+
+header small {
+    padding: 4px 8px;
+    border-radius: 6px;
 }

--- a/docs/assets/js/app.js
+++ b/docs/assets/js/app.js
@@ -373,30 +373,6 @@ Array.from(document.querySelectorAll('a')).concat(Array.from(document.querySelec
 });
 }
 
-if (!window.is_iso) {
-fetch(`https://api.github.com/repos/${window.appconfig.repo}/commits?path=${window.appconfig.path}`).then(r => r.json()).then(j => {
-    if (document.getElementById('contributors') === null) {
-        return;
-    }
-    let n = {};
-    j.forEach(c => {
-        n[c.author.avatar_url] = (n[c.author.avatar_url || 0]) + 1;
-    });
-    let es = Object.entries(n);
-    document.getElementById('contributors').appendChild(
-        document.createTextNode(es.length + ' contributor(s): ')
-    );
-    es.map(kv => [kv[1], kv[0]]).sort().forEach(kv => {
-        let img = document.createElement('img');
-        img.src = kv[1] + '&s=32';
-        img.classList.add('contributor-icon');
-        document.getElementById('contributors').appendChild(img);
-    });
-    document.getElementById('last-change').innerHTML += 'Last change: ' +
-    '<em>' + j[0].commit.message + '</em>' + ' by ' + j[0].commit.author.name + ' on ' + (new Date(j[0].commit.author.date)).toLocaleString();
-});
-}
-
 setupInheritanceToggle();
 setupConceptDiagramCanvas();
 if (!document.body.classList.contains('terms-and-definitions') && !document.body.classList.contains('cover')) {


### PR DESCRIPTION
### 2eb94f675 Fix search by rewriting form.action to relative as well

The templates are still based on absolute URLs because this was easiest in the old approach (`/search` is always the same no matter where you are at which depth) but in the new static HTML zip the archive can be moved at different depths without the generator knowing. This was addressed by rewriting URLs to be relative, but form.action was missed as a rewrite target, so the search form submitted to the wrong place.

### d911b583b Add a status to version.json and render in the top

As discussed. Some early ideas for how to render the status along with the version.

<img width="755" height="205" alt="afbeelding" src="https://github.com/user-attachments/assets/b7264d59-0825-452a-b8f0-37c4e849b5ce" />

### 67d913408 Adapt latest contributors to use local git instead of client-side JS

Previously the latest contributors used the Github API using client-side JS. I found this not very hygienic, but most importantly it would be blatantly wrong in cases where the ZIP somehow was behind the latest version. Computing this from the generation-time local checkout is more efficient.

### 24e7661a6 generate.html --include and --no-index option to speed up generation for debugging runs

Mostly for testing and development, you can now emit a single HTML for a single path to test without rebuilding the full search index.