### PR TITLE
Cherry-pick schema name + search fixes from the preview branch

### DIFF
--- a/code/generators/util/xmi_document.py
+++ b/code/generators/util/xmi_document.py
@@ -35,7 +35,10 @@ else:
     # (IFC4X4) instead of a per-commit dev placeholder.
     try:
         import json as _json
-        _version_tuple = _json.load(open(os.path.join(os.path.dirname(__file__), "..", "..", "version.json")))
+        _version_tuple = _json.load(open(os.path.join(os.path.dirname(__file__), "..", "..", "version.json"), encoding="utf-8"))
+        if isinstance(_version_tuple, dict):
+            # PR #1170 turns version.json into {"version": [...], "status": ...}
+            _version_tuple = _version_tuple["version"]
         _prefixes = ("IFC", "X", "_ADD", "_TC")
         SCHEMA_NAME = "".join("".join(map(str, t)) if t[1] else "" for t in zip(_prefixes, _version_tuple))
     except Exception:

--- a/code/generators/util/xmi_document.py
+++ b/code/generators/util/xmi_document.py
@@ -30,16 +30,24 @@ is_package = os.environ.get('PACKAGE', '0') == '1'
 if is_package or is_iso:
     SCHEMA_NAME = "IFC4X3_ADD2"
 else:
-    SCHEMA_NAME = "IFC4X3_DEV"
-
+    # Derive the schema name from code/version.json (same recipe as code/version.py),
+    # so where rules, functions and the SCHEMA header all carry the real name
+    # (IFC4X4) instead of a per-commit dev placeholder.
     try:
-        if os.environ.get("REPO_DIR"):
-            repo_dir = "-C", os.environ.get("REPO_DIR")
-        else:
-            repo_dir = []
-        sha = subprocess.check_output(["git", *repo_dir, "rev-parse", "--short", "HEAD"]).decode('ascii').strip()
-        SCHEMA_NAME += f"_{sha}"
-    except: pass
+        import json as _json
+        _version_tuple = _json.load(open(os.path.join(os.path.dirname(__file__), "..", "..", "version.json")))
+        _prefixes = ("IFC", "X", "_ADD", "_TC")
+        SCHEMA_NAME = "".join("".join(map(str, t)) if t[1] else "" for t in zip(_prefixes, _version_tuple))
+    except Exception:
+        SCHEMA_NAME = "IFC4X3_DEV"
+        try:
+            if os.environ.get("REPO_DIR"):
+                repo_dir = "-C", os.environ.get("REPO_DIR")
+            else:
+                repo_dir = []
+            sha = subprocess.check_output(["git", *repo_dir, "rev-parse", "--short", "HEAD"]).decode('ascii').strip()
+            SCHEMA_NAME += f"_{sha}"
+        except: pass
 
 def unescape(s):
     # @todo this is bizarre encoding, what happened here?
@@ -380,7 +388,7 @@ class xmi_document:
                     yield xmi_item(
                         (c|"language").text.split('_')[-1], 
                         c.name, 
-                        (c|"body").text.strip(), 
+                        fix_schema_name((c|"body").text.strip()), 
                         c, 
                         document=self
                     )
@@ -505,7 +513,7 @@ class xmi_document:
                     parts.append(supert)
                     supert = " ".join(parts)
                 
-                constraints = [(r.name, (r|"body").text) for r in c/"ownedRule" if (r|"language").text == 'EXPRESS_WHERE']
+                constraints = [(r.name, fix_schema_name((r|"body").text)) for r in c/"ownedRule" if (r|"language").text == 'EXPRESS_WHERE']
                 if ocl := next(((r|"body").text for r in c/"ownedRule" if (r|"language").text == 'OCL'), None):
                     if m := re.match(r'self\.size\(\) (=|<=) (\d+)', ocl):
                         op, sz = m.groups()
@@ -651,7 +659,7 @@ class xmi_document:
                                 ("CorrectTypeAssigned", f"(SIZEOF(IsTypedBy) = 0) OR\n  ('{SCHEMA_NAME}.{c.name.upper()}TYPE' IN TYPEOF(SELF\\IfcObject.IsTypedBy[1].RelatingType))")
                             )
 
-                where_rules = sorted([*((r.name, (r|"body").text) for r in c/"ownedRule" if (r|"language").text == 'EXPRESS_WHERE'), *generated_whererules])
+                where_rules = sorted([*((r.name, fix_schema_name((r|"body").text)) for r in c/"ownedRule" if (r|"language").text == 'EXPRESS_WHERE'), *generated_whererules])
                 unique_rules = sorted((r.name, (r|"body").text) for r in c/"ownedRule" if (r|"language").text == 'EXPRESS_UNIQUE')
 
                 express_entity = express.entity(c.name, attributes, 

--- a/code/templates/main.html
+++ b/code/templates/main.html
@@ -10,6 +10,7 @@
     <title>{{ spec_version_string }} Documentation {{ relative_base }} {{ relative_base }}</title>
     {% endif %}
     <link rel="icon" type="image/x-icon" href="{{ relative_base }}/assets/img/favicon.ico">
+    <link id="site-root" href="{{ relative_base }}/">
     <script>window.is_iso = {% if is_iso %}true{% else %}false{% endif %};</script>
 </head>
 <body class="{{body_class or ''}}">
@@ -209,7 +210,6 @@
             'base': '{{ base }}',
             'repo': '{{ repo or "buildingSMART/IFC4.3.x-development" }}',
             'resourceApi': null,
-            'searchIndex': '{{ base }}/assets/search/search-index.json',
         };
     </script>
     <script>

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -1,3 +1,10 @@
+// The site is published under a sub-path, so absolute URLs cannot be used.
+// #site-root carries the (refiner-relativised) path back to the site root.
+function siteRoot() {
+    const el = document.getElementById('site-root');
+    return el ? el.href : document.baseURI;
+}
+
 (function () {
     function normaliseQuery(value) {
         return (value || '').trim();
@@ -38,7 +45,7 @@
 
             let title = document.createElement('a');
             title.className = 'search-result-title';
-            title.href = item.path;
+            title.href = new URL(item.path.replace(/^\//, ''), siteRoot()).href;
             title.textContent = item.title;
             li.appendChild(title);
 
@@ -73,7 +80,7 @@
         });
 
         try {
-            let response = await fetch(window.appconfig.searchIndex);
+            let response = await fetch(new URL('assets/search/search-index.json', siteRoot()));
             if (!response.ok) {
                 throw new Error(`Failed to load search index: ${response.status}`);
             }


### PR DESCRIPTION
Both are already on ifc4.4-preview; this brings them to ifc4.4-main,

- EXPRESS & XSD filenames change on every publish. They contain the commit sha, so the landing page link is currently dead ((IFC4X3_DEV_dd97e9c). With SCHEMA_NAME from version.json it becomes IFC4X4.exp / IFC4X4.xsd. 
Also requires an update of hte landing page. 

- Include search fix
- Include PR #1170  https://github.com/buildingSMART/IFC4.x-development/pull/1170

Next: add same commits to ifc4.3-main
